### PR TITLE
Actionbar paging fixes

### DIFF
--- a/KkthnxUI/Config/Settings.lua
+++ b/KkthnxUI/Config/Settings.lua
@@ -13,6 +13,8 @@ local MAX_PLAYER_LEVEL = _G.MAX_PLAYER_LEVEL
 local MINIMIZE = _G.MINIMIZE
 local NONE = _G.NONE
 
+local _,PlayerClass = UnitClass("player")
+
 -- Actionbar
 C["ActionBar"] = {
 	["AddNewSpells"] = true,
@@ -20,7 +22,7 @@ C["ActionBar"] = {
 	["ButtonSize"] = 34,
 	["ButtonSpace"] = 6,
 	["Cooldowns"] = true,
-	["DisableStancePages"] = false,
+	["DisableStancePages"] = PlayerClass == "DRUID", -- don't need a stealth bar for druids
 	["Enable"] = true,
 	["EquipBorder"] = true,
 	["Font"] = "KkthnxUI Outline",

--- a/KkthnxUI/Modules/ActionBars/Bar1.lua
+++ b/KkthnxUI/Modules/ActionBars/Bar1.lua
@@ -7,7 +7,6 @@ local _G = _G
 local select = select
 
 local CreateFrame = _G.CreateFrame
-local Druid, Rogue = "", ""
 local GetActionTexture = _G.GetActionTexture
 local HasOverrideActionBar = _G.HasOverrideActionBar
 local HasVehicleActionBar = _G.HasVehicleActionBar
@@ -15,6 +14,8 @@ local InCombatLockdown = _G.InCombatLockdown
 local NUM_ACTIONBAR_BUTTONS = _G.NUM_ACTIONBAR_BUTTONS
 local RegisterStateDriver = _G.RegisterStateDriver
 local UnitClass = _G.UnitClass
+
+local Druid, Rogue
 
 local ActionBar1 = CreateFrame("Frame", "Bar1Holder", ActionBarAnchor, "SecureHandlerStateTemplate")
 ActionBar1:SetAllPoints(ActionBarAnchor)
@@ -33,15 +34,21 @@ for i = 1, 12 do
 	end
 end
 
-if (not C["ActionBar"].DisableStancePages) then
-	Rogue = "[bonusbar:1] 7;"
+if (C["ActionBar"].DisableStancePages) then
+	Druid = "[bonusbar:1,nostealth] 7; [bonusbar:1,stealth] 7; [bonusbar:2] 8; [bonusbar:3] 9; [bonusbar:4] 10;"
+else 
 	Druid = "[bonusbar:1,nostealth] 7; [bonusbar:1,stealth] 8; [bonusbar:2] 8; [bonusbar:3] 9; [bonusbar:4] 10;"
+	Rogue = "[bonusbar:1] 7;"
 end
 
 local Page = {
 	["DRUID"] = Druid,
 	["ROGUE"] = Rogue,
-	["DEFAULT"] = "[vehicleui][possessbar] 12; [shapeshift] 13; [overridebar] 14; [bar:2] 2; [bar:3] 3; [bar:4] 4; [bar:5] 5; [bar:6] 6;",
+	["MONK"] = "[bonusbar:1] 7; [bonusbar:2] 8; [bonusbar:3] 9;",
+	["PRIEST"] = "[bonusbar:1] 7;",
+	["WARRIOR"] = "[bonusbar:1] 7; [bonusbar:2] 8;",
+	
+	["DEFAULT"] = "[vehicleui][overridebar][possessbar][shapeshift] possess; [bar:2] 2; [bar:3] 3; [bar:4] 4; [bar:5] 5; [bar:6] 6;",
 }
 
 local function GetBar()
@@ -53,7 +60,7 @@ local function GetBar()
 		condition = condition .. " " .. page
 	end
 
-	condition = condition .. " 1"
+	condition = condition .. "; [form] 1; 1"
 
 	return condition
 end
@@ -76,6 +83,22 @@ ActionBar1:SetScript("OnEvent", function(self, event)
 		]])
 
 		self:SetAttribute("_onstate-page", [[
+		if (newstate == "possess") or (newstate == "11") then
+			if HasVehicleActionBar() then
+				newstate = GetVehicleBarIndex() 
+			elseif HasOverrideActionBar() then 
+				newstate = GetOverrideBarIndex() 
+			elseif HasTempShapeshiftActionBar() then
+				newstate = GetTempShapeshiftBarIndex() 
+			elseif HasBonusActionBar() and (GetActionBarPage() == 1) then 
+				newstate = GetBonusBarIndex()
+			else
+				newstate = nil
+			end
+			if (not value) then
+				newstate = 12 
+			end
+		end
 		for i, button in ipairs(buttons) do
 			button:SetAttribute("actionpage", tonumber(newstate))
 		end

--- a/KkthnxUI_Config/Locales/deDE.lua
+++ b/KkthnxUI_Config/Locales/deDE.lua
@@ -338,8 +338,8 @@ KkthnxUIConfig["deDE"] = {
 		},
 
 		["DisableStancePages"] = {
-			["Name"] = "Disable Stance Pages",
-			["Desc"] = "Disables automatic page-switching depending on the players stance. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
+			["Name"] = "Disable Stealth Paging",
+			["Desc"] = "Disables automatic page-switching when stealthed. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
 		},
 
 		["PetBarHide"] = {

--- a/KkthnxUI_Config/Locales/enUS.lua
+++ b/KkthnxUI_Config/Locales/enUS.lua
@@ -333,8 +333,8 @@ KkthnxUIConfig["enUS"] = {
 		},
 
 		["DisableStancePages"] = {
-			["Name"] = "Disable Stance Pages",
-			["Desc"] = "Disables automatic page-switching depending on the players stance. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
+			["Name"] = "Disable Stealth Paging",
+			["Desc"] = "Disables automatic page-switching when stealthed. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
 		},
 
 		["PetBarHide"] = {

--- a/KkthnxUI_Config/Locales/esES.lua
+++ b/KkthnxUI_Config/Locales/esES.lua
@@ -338,8 +338,8 @@ KkthnxUIConfig["esES"] = {
 		},
 
 		["DisableStancePages"] = {
-			["Name"] = "Disable Stance Pages",
-			["Desc"] = "Disables automatic page-switching depending on the players stance. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
+			["Name"] = "Disable Stealth Paging",
+			["Desc"] = "Disables automatic page-switching when stealthed. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
 		},
 
 		["PetBarHide"] = {

--- a/KkthnxUI_Config/Locales/esMX.lua
+++ b/KkthnxUI_Config/Locales/esMX.lua
@@ -338,8 +338,8 @@ KkthnxUIConfig["esMX"] = {
 		},
 
 		["DisableStancePages"] = {
-			["Name"] = "Disable Stance Pages",
-			["Desc"] = "Disables automatic page-switching depending on the players stance. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
+			["Name"] = "Disable Stealth Paging",
+			["Desc"] = "Disables automatic page-switching when stealthed. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
 		},
 
 		["PetBarHide"] = {

--- a/KkthnxUI_Config/Locales/frFR.lua
+++ b/KkthnxUI_Config/Locales/frFR.lua
@@ -338,8 +338,8 @@ KkthnxUIConfig["frFR"] = {
 		},
 
 		["DisableStancePages"] = {
-			["Name"] = "Disable Stance Pages",
-			["Desc"] = "Disables automatic page-switching depending on the players stance. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
+			["Name"] = "Disable Stealth Paging",
+			["Desc"] = "Disables automatic page-switching when stealthed. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
 		},
 
 		["PetBarHide"] = {

--- a/KkthnxUI_Config/Locales/itIT.lua
+++ b/KkthnxUI_Config/Locales/itIT.lua
@@ -338,8 +338,8 @@ KkthnxUIConfig["itIT"] = {
 		},
 
 		["DisableStancePages"] = {
-			["Name"] = "Disable Stance Pages",
-			["Desc"] = "Disables automatic page-switching depending on the players stance. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
+			["Name"] = "Disable Stealth Paging",
+			["Desc"] = "Disables automatic page-switching when stealthed. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
 		},
 
 		["PetBarHide"] = {

--- a/KkthnxUI_Config/Locales/koKR.lua
+++ b/KkthnxUI_Config/Locales/koKR.lua
@@ -338,8 +338,8 @@ KkthnxUIConfig["koKR"] = {
 		},
 
 		["DisableStancePages"] = {
-			["Name"] = "Disable Stance Pages",
-			["Desc"] = "Disables automatic page-switching depending on the players stance. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
+			["Name"] = "Disable Stealth Paging",
+			["Desc"] = "Disables automatic page-switching when stealthed. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
 		},
 
 		["PetBarHide"] = {

--- a/KkthnxUI_Config/Locales/ptBR.lua
+++ b/KkthnxUI_Config/Locales/ptBR.lua
@@ -338,8 +338,8 @@ KkthnxUIConfig["ptBR"] = {
 		},
 
 		["DisableStancePages"] = {
-			["Name"] = "Disable Stance Pages",
-			["Desc"] = "Disables automatic page-switching depending on the players stance. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
+			["Name"] = "Disable Stealth Paging",
+			["Desc"] = "Disables automatic page-switching when stealthed. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
 		},
 
 		["PetBarHide"] = {

--- a/KkthnxUI_Config/Locales/ruRU.lua
+++ b/KkthnxUI_Config/Locales/ruRU.lua
@@ -338,8 +338,8 @@ KkthnxUIConfig["ruRU"] = {
 		},
 
 		["DisableStancePages"] = {
-			["Name"] = "Disable Stance Pages",
-			["Desc"] = "Disables automatic page-switching depending on the players stance. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
+			["Name"] = "Disable Stealth Paging",
+			["Desc"] = "Disables automatic page-switching when stealthed. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
 		},
 
 		["PetBarHide"] = {

--- a/KkthnxUI_Config/Locales/zhCN.lua
+++ b/KkthnxUI_Config/Locales/zhCN.lua
@@ -338,8 +338,8 @@ KkthnxUIConfig["zhCN"] = {
 		},
 
 		["DisableStancePages"] = {
-			["Name"] = "Disable Stance Pages",
-			["Desc"] = "Disables automatic page-switching depending on the players stance. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
+			["Name"] = "Disable Stealth Paging",
+			["Desc"] = "Disables automatic page-switching when stealthed. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
 		},
 
 		["PetBarHide"] = {

--- a/KkthnxUI_Config/Locales/zhTW.lua
+++ b/KkthnxUI_Config/Locales/zhTW.lua
@@ -338,8 +338,8 @@ KkthnxUIConfig["zhTW"] = {
 		},
 
 		["DisableStancePages"] = {
-			["Name"] = "Disable Stance Pages",
-			["Desc"] = "Disables automatic page-switching depending on the players stance. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
+			["Name"] = "Disable Stealth Paging",
+			["Desc"] = "Disables automatic page-switching when stealthed. |n|nOnly affects |cffFFF569Rogues|r and |cffFF7D0ADruids|r, has no effect on other classes",
 		},
 
 		["PetBarHide"] = {


### PR DESCRIPTION
- Updated the default page drivers to be in line with the current class defaults in BfA. 
- Changed the menu option to disable page switching to instead toggle the stealth page switching for both Rogues and now Druids, and updated menu text to indicate this.  