### PR TITLE
Fix the missing actionbars in "Cycle of Life" world quest

### DIFF
--- a/KkthnxUI/Modules/ActionBars/Bar1.lua
+++ b/KkthnxUI/Modules/ActionBars/Bar1.lua
@@ -32,7 +32,7 @@ for i = 1, NUM_ACTIONBAR_BUTTONS do
 end
 
 local function GetPageDriver()
-	local driver = "[vehicleui]vehicle; [overridebar]override; [possessbar]possess; [shapeshift]shapeshift; [bar:2]2; [bar:3]3; [bar:4]4; [bar:5]5; [bar:6]6"
+	local driver = "[overridebar]override; [possessbar]possess; [shapeshift]shapeshift; [vehicleui]vehicle; [bar:2]2; [bar:3]3; [bar:4]4; [bar:5]5; [bar:6]6"
 
 	if (K.Class == "DRUID") then
 		if (C["ActionBar"].DisableStancePages) then


### PR DESCRIPTION
In 8.1.5 we got a new world quest where you get a vehicleui but not a vehicle actionbar. Instead blizzard are using an overridebar. To work around this issue, we moved the vehicleui conditional to the back of the line, so overridebar, possessbar and the other bar variations will fire first, thus giving us... buttons!